### PR TITLE
Add self-update target

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -13,3 +13,7 @@ render-defaults:
 .PHONY: clean
 clean:
 	@find temp/ -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
+
+.PHONY: update
+update:
+	@uv run copier update --trust --defaults

--- a/template/template/.gitignore.jinja.jinja
+++ b/template/template/.gitignore.jinja.jinja
@@ -1,4 +1,5 @@
 .DS_Store
+.env
 
 # LCAF rules
 components/


### PR DESCRIPTION
Adds a `make update` command to the Makefile generated for downstream templates that will provide an easy shortcut for self-updates.

As this is the base template and doesn't contain a Makefile, there's no self-update behavior planned for this repo.

Additionally, `.env` is now present in our global .gitignore.