### PR TITLE
Swap Python dependency for uv, add uv dependency to child templates

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 pre-commit 4.2.0
-python 3.13
+uv 0.7.21

--- a/template/template/.tool-versions.jinja.jinja
+++ b/template/template/.tool-versions.jinja.jinja
@@ -1,3 +1,4 @@
 pre-commit 4.2.0
+uv 0.7.21
 {{ "{%" }} block template_toolversions {{ "%}" }}
 {{ "{%" }} endblock template_toolversions {{ "-%}" }}


### PR DESCRIPTION
Since `uv` can manage Python versions based on the contents of `pyproject.toml`, we don't really need an explicit Python version in our `.tool-versions` anymore.

We do want to pass the `uv` dependency down to all child templates, since we're using `uv` to manage running our tests and the copier self-update process.